### PR TITLE
Ensure that url, urlpath, urlid are handled consistently with id field

### DIFF
--- a/src/main/java/se/repos/indexing/item/HandlerHeadClone.java
+++ b/src/main/java/se/repos/indexing/item/HandlerHeadClone.java
@@ -50,6 +50,14 @@ public class HandlerHeadClone implements IndexingItemHandler {
 		IndexingDoc fields = progress.getFields();
 		String id = (String) fields.getFieldValue("id");
 		String idHead = (String) fields.getFieldValue("idhead");
+		String url = (String) fields.getFieldValue("url");
+		String urlHead = (String) fields.getFieldValue("urlhead");
+		String urlPath = (String) fields.getFieldValue("urlpath");
+		String urlPathHead = (String) fields.getFieldValue("urlpathhead");
+		// Needed when using an urlid handler.
+		String urlId = (String) fields.getFieldValue("urlid");
+		String urlIdHead = (String) fields.getFieldValue("urlidhead");
+		
 		
 		if (id == null) {
 			throw new IllegalStateException("Field 'id' must be set by preceeding handler.");
@@ -72,12 +80,18 @@ public class HandlerHeadClone implements IndexingItemHandler {
 		} else {
 			// Set ID to idHead for the purpose of adding the item representing latest.
 			fields.setField("id", idHead);
+			fields.setField("url", urlHead);
+			fields.setField("urlpath", urlPathHead);
+			fields.setField("urlid", urlIdHead);
 			// Setting head = true on folders as well.
 			fields.setField("head", true);
 			new SolrAdd(repositem, fields).run();
 			
 			// Restore the id with revision.
 			fields.setField("id", id);
+			fields.setField("url", url);
+			fields.setField("urlpath", urlPath);
+			fields.setField("urlid", urlId);
 		}
 		// Flag 'head' is always false when returning, subsequent handlers will add the item representing history.
 		fields.setField("head", false);

--- a/src/main/java/se/repos/indexing/item/HandlerPathinfo.java
+++ b/src/main/java/se/repos/indexing/item/HandlerPathinfo.java
@@ -148,8 +148,11 @@ public class HandlerPathinfo implements IndexingItemHandler {
 		}
 		
 		CmsItemId url = repository.getItemId().withRelPath(path);
-		d.setField("url", url.getUrl());
-		d.setField("urlpath", url.getUrlAtHost());
+		String urlRevSuffix = "?p=".concat(Long.toString(revision.getNumber()));
+		d.setField("url", url.getUrl().concat(urlRevSuffix));
+		d.setField("urlhead", url.getUrl());
+		d.setField("urlpath", url.getUrlAtHost().concat(urlRevSuffix));
+		d.setField("urlpathhead", url.getUrlAtHost());
 	}
 	
 	@Override

--- a/src/main/resources/se/repos/indexing/solr/repositem/conf/schema.xml
+++ b/src/main/resources/se/repos/indexing/solr/repositem/conf/schema.xml
@@ -61,12 +61,13 @@
 		
 		<!-- URL of the resource -->
 		<field name="url"       type="string" indexed="true" stored="true" multiValued="false"/>
-		<!-- URL, with ?p=[revision] -->
-		<!-- any practical use? <field name="urlrev"    type="string" indexed="true" stored="true" multiValued="false"/>  -->
+		<field name="urlhead"   type="string" indexed="true" stored="true" multiValued="false"/>
 		<!-- URL at host, encoded (unlike pathfull if we keep that one), without revision -->
 		<field name="urlpath"       type="string" indexed="true" stored="true" multiValued="false"/>
+		<field name="urlpathhead"   type="string" indexed="true" stored="true" multiValued="false"/>
 		<!-- Logical ID -->
 		<field name="urlid"       type="string" indexed="true" stored="true" multiValued="false"/>
+		<field name="urlidhead"   type="string" indexed="true" stored="true" multiValued="false"/>
 		
 		<!-- repository name, no slashes -->
 		<field name="repo"       type="string" indexed="true" stored="true" multiValued="false"/>

--- a/src/test/java/se/repos/indexing/item/HandlerPathinfoTest.java
+++ b/src/test/java/se/repos/indexing/item/HandlerPathinfoTest.java
@@ -83,8 +83,10 @@ public class HandlerPathinfoTest {
 		assertEquals(rev.getNumber() - 2, f.getFieldValue("revc"));
 		assertEquals(new Date(rev.getDate().getTime() - 1000), f.getFieldValue("revct"));
 		
-		assertEquals("https://h.ost:1080/svn/repo1/my/dir/a%20file.txt", f.getFieldValue("url"));
-		assertEquals("/svn/repo1/my/dir/a%20file.txt", f.getFieldValue("urlpath"));
+		assertEquals("https://h.ost:1080/svn/repo1/my/dir/a%20file.txt?p=10", f.getFieldValue("url"));
+		assertEquals("https://h.ost:1080/svn/repo1/my/dir/a%20file.txt", f.getFieldValue("urlhead"));
+		assertEquals("/svn/repo1/my/dir/a%20file.txt?p=10", f.getFieldValue("urlpath"));
+		assertEquals("/svn/repo1/my/dir/a%20file.txt", f.getFieldValue("urlpathhead"));
 		
 		assertEquals("repo1", f.getFieldValue("repo"));
 		assertEquals("h.ost:1080", f.getFieldValue("repohost"));
@@ -171,7 +173,7 @@ public class HandlerPathinfoTest {
 		pathinfo.handle(p);
 		
 		assertEquals("Should use CmsRepository's URL encoding",
-				"https://h.ost:1080/svn/repo1/my%20file$txt", p.getFields().getFieldValue("url"));
+				"https://h.ost:1080/svn/repo1/my%20file$txt", p.getFields().getFieldValue("urlhead"));
 	}
 	
 	@Test

--- a/src/test/java/se/repos/indexing/repository/ReposIndexingPerRepositoryIntegrationTest.java
+++ b/src/test/java/se/repos/indexing/repository/ReposIndexingPerRepositoryIntegrationTest.java
@@ -5,6 +5,7 @@ package se.repos.indexing.repository;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
@@ -156,6 +157,13 @@ public class ReposIndexingPerRepositoryIntegrationTest {
 		tearDownSolrRepositem();
 	}
 	
+	private String getTail(Object id) {
+		
+		String str = (String) id;
+		String[] split = str.split("/");
+		return split[split.length-1];
+	}
+	
 	@Test
 	public void testMarkItemHead() throws SolrServerException, IOException {
 		InputStream dumpfile = this.getClass().getClassLoader().getResourceAsStream(
@@ -208,6 +216,14 @@ public class ReposIndexingPerRepositoryIntegrationTest {
 		SolrDocumentList r2 = repositem.query(new SolrQuery("id:*@0000000002").setSort("path", ORDER.asc)).getResults();
 		assertEquals("all rev items have head=false, " + r2.get(0), false, r2.get(0).get("head"));
 		assertAllHeadFalse(r2);
+		assertEquals("id has rev when head=false, " + r2.get(0), "t1.txt@0000000002", getTail(r2.get(0).get("id")));
+		assertEquals("idhead never has rev, " + r2.get(0), "t1.txt", getTail(r2.get(0).get("idhead")));
+		// url never had revision before repos-indexing 0.20
+		assertEquals("url has rev when head=false, " + r2.get(0), "t1.txt?p=2", getTail(r2.get(0).get("url")));
+		assertEquals("urlhead never has rev, " + r2.get(0), "t1.txt", getTail(r2.get(0).get("urlhead")));
+		assertEquals("url has rev when head=false, " + r2.get(0), "t1.txt?p=2", getTail(r2.get(0).get("urlpath")));
+		assertEquals("urlhead never has rev, " + r2.get(0), "t1.txt", getTail(r2.get(0).get("urlpathhead")));
+		assertNull("urlid is null because the handler is not in repos-indexing core, " + r2.get(0), r2.get(0).get("urlid"));
 		r2 = null;
 		
 		// Verify r2 head:true
@@ -222,6 +238,13 @@ public class ReposIndexingPerRepositoryIntegrationTest {
 		assertEquals("...", 1L, r2Head.get(0).get("revc"));
 		assertEquals("...", 1L, r2Head.get(1).get("revc"));
 		assertEquals("...", 2L, r2Head.get(2).get("revc"));
+		assertEquals("id has no rev when head=true, " + r2Head.get(2), "t1.txt", getTail(r2Head.get(2).get("id")));
+		assertEquals("idhead never has rev, " + r2Head.get(2), "t1.txt", getTail(r2Head.get(2).get("idhead")));
+		assertEquals("id has no rev when head=true, " + r2Head.get(2), "t1.txt", getTail(r2Head.get(2).get("url")));
+		assertEquals("idhead never has rev, " + r2Head.get(2), "t1.txt", getTail(r2Head.get(2).get("urlhead")));
+		assertEquals("id has no rev when head=true, " + r2Head.get(2), "t1.txt", getTail(r2Head.get(2).get("urlpath")));
+		assertEquals("idhead never has rev, " + r2Head.get(2), "t1.txt", getTail(r2Head.get(2).get("urlpathhead")));
+		assertNull("urlid is null because the handler is not in repos-indexing core, " + r2Head.get(2), r2Head.get(2).get("urlid"));
 		r2Head = null;
 		
 				


### PR DESCRIPTION
Ensure that url, urlpath, urlid are handled consistent with id field (all have corresponding head fields).

Functional change: url, urlpath now contains revision when item represents a revision.