### PR TITLE
High level categorization

### DIFF
--- a/src/main/resources/se/repos/indexing/solr/repositem/conf/schema.xml
+++ b/src/main/resources/se/repos/indexing/solr/repositem/conf/schema.xml
@@ -141,6 +141,8 @@
 		<!-- Useful commonality that can be found in prop_* or embd_* or somewhere else added as copyField or custom indexing handler -->
 		<field name="title" type="text_general" indexed="true" stored="true" multiValued="false" />
 		<field name="keywords" type="metadata" indexed="true" stored="true" multiValued="false" />
+		<!-- High level categorization suitable for the users of the system, e.g.: image, office, text, programming. -->
+		<field name="category" type="string" indexed="true" stored="true" multiValued="true" />
 		
 		<!-- 
 			References, free form per type.


### PR DESCRIPTION
High level categorization suitable for the users of the system, e.g.: image, office, text, programming.

This is not quite the same as 'filetype' as used by Google and Duck Duck Go.

This can be higher level in some aspects but very specific for the aspects the CMS is aimed for, e.g. list XML root elements for XML but all code in a single 'programming' category regardless of language.