### PR TITLE
Solr upgradability to 8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
 		</repository>		
 	</repositories>
 
+	<properties>
+		<solr-version>6.6.6</solr-version>
+	</properties>	
+
 	<dependencies>
 		<dependency>
 			<groupId>se.simonsoft</groupId>
@@ -43,7 +47,7 @@
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-solrj</artifactId>
-			<version>6.6.6</version>
+			<version>${solr-version}</version>
 		</dependency>
 		<!-- Not used at this time. See ItemContentsStream. 
 		<dependency>
@@ -55,7 +59,7 @@
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-test-framework</artifactId>
-			<version>6.6.6</version>
+			<version>${solr-version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/src/main/java/se/repos/indexing/solrj/HttpSolrServerNamed.java
+++ b/src/main/java/se/repos/indexing/solrj/HttpSolrServerNamed.java
@@ -3,8 +3,6 @@
  */
 package se.repos.indexing.solrj;
 
-import org.apache.http.client.HttpClient;
-import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;;
 
 /**
@@ -13,10 +11,18 @@ import org.apache.solr.client.solrj.impl.HttpSolrClient;;
  */
 public class HttpSolrServerNamed extends HttpSolrClient {
 
+	// SolR 8.8.0
+	/*
+	public HttpSolrServerNamed(String baseURL) {
+		super(new Builder(baseURL));
+	}
+	*/
+	// SolR 6.6.6
 	public HttpSolrServerNamed(String baseURL) {
 		super(baseURL);
 	}
 
+	/*
 	public HttpSolrServerNamed(String baseURL, HttpClient client) {
 		super(baseURL, client);
 	}
@@ -24,6 +30,7 @@ public class HttpSolrServerNamed extends HttpSolrClient {
 	public HttpSolrServerNamed(String arg0, HttpClient arg1, ResponseParser arg2) {
 		super(arg0, arg1, arg2);
 	}
+	*/
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/resources/se/repos/indexing/solr/repositem/conf/schema.xml
+++ b/src/main/resources/se/repos/indexing/solr/repositem/conf/schema.xml
@@ -189,12 +189,6 @@
 
 	<!-- field to use to determine and enforce document uniqueness. -->
 	<uniqueKey>id</uniqueKey>
-
-	<!-- field for the QueryParser to use when an explicit fieldname is absent -->
-	<defaultSearchField>id</defaultSearchField>
-
-	<!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-	<solrQueryParser defaultOperator="OR" />
 	
 	<types>
 		<fieldtype name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true" />

--- a/src/main/resources/se/repos/indexing/solr/repositem/conf/solrconfig.xml
+++ b/src/main/resources/se/repos/indexing/solr/repositem/conf/solrconfig.xml
@@ -9,7 +9,7 @@
  It is *not* a good example to work from. 
 -->
 <config>
-  <luceneMatchVersion>4.5</luceneMatchVersion>
+  <luceneMatchVersion>6.6.6</luceneMatchVersion>
   <!--  The DirectoryFactory to use for indexes.
         solr.StandardDirectoryFactory, the default, is filesystem based.
         solr.RAMDirectoryFactory is memory based, not persistent, and doesn't work with replication. -->
@@ -17,6 +17,7 @@
 
   <dataDir>${solr.repositem.data.dir:}</dataDir>
 
+  <!-- ClassicIndexSchemaFactory requires the use of a schema.xml configuration file, and disallows any programatic changes to the Schema at run time. -->
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 
   <updateHandler class="solr.DirectUpdateHandler2">
@@ -47,14 +48,6 @@
   <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" />
   -->
 
-  <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
-    <lst name="invariants">
-      <str name="q">solrpingquery</str>
-    </lst>
-    <lst name="defaults">
-      <str name="echoParams">all</str>
-    </lst>
-  </requestHandler>
    
   <!-- config for the admin interface --> 
   <admin>

--- a/src/test/java/se/repos/indexing/repository/ReposIndexingPerRepositoryIntegrationTest.java
+++ b/src/test/java/se/repos/indexing/repository/ReposIndexingPerRepositoryIntegrationTest.java
@@ -28,7 +28,6 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreContainer;
-import org.apache.solr.core.SolrResourceLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -142,9 +141,7 @@ public class ReposIndexingPerRepositoryIntegrationTest {
 		FileUtils.copyDirectory(coreSource, new File(instanceDir, coreName));
 		FileUtils.copyFile(new File(coreSource.getParentFile(),  "testing-home/solr.xml"), new File(instanceDir, "solr.xml"));
 		
-		SolrResourceLoader solrResourceLoader = new SolrResourceLoader(instanceDir.toPath());
-		CoreContainer solrCoreContainer = new CoreContainer(solrResourceLoader);
-		solrCoreContainer.load();
+		CoreContainer solrCoreContainer = CoreContainer.createAndLoad(instanceDir.toPath());
 		final SolrClient repositem = new EmbeddedSolrServer(solrCoreContainer, "repositem");
 		forTearDown = (EmbeddedSolrServer) repositem;
 		return repositem;


### PR DESCRIPTION
 - Lucene match updated to 6.6.6.
 - Removed desupported config